### PR TITLE
Redesign setup screen with badminton court layout

### DIFF
--- a/src/components/shared/PlayerNameInput.tsx
+++ b/src/components/shared/PlayerNameInput.tsx
@@ -1,13 +1,33 @@
-import { StyleSheet, Text, TextInput, TextInputProps, View } from 'react-native';
+import {
+  StyleSheet,
+  Text,
+  TextInput,
+  TextInputProps,
+  View,
+  type StyleProp,
+  type TextStyle,
+  type ViewStyle,
+} from 'react-native';
 
 import { useColorScheme } from '#/hooks/use-color-scheme';
 
 export type PlayerNameInputProps = TextInputProps & {
   label: string;
   errorMessage?: string;
+  containerStyle?: StyleProp<ViewStyle>;
+  labelStyle?: StyleProp<TextStyle>;
+  errorTextStyle?: StyleProp<TextStyle>;
 };
 
-export function PlayerNameInput({ label, errorMessage, style, ...textInputProps }: PlayerNameInputProps) {
+export function PlayerNameInput({
+  label,
+  errorMessage,
+  style,
+  containerStyle,
+  labelStyle,
+  errorTextStyle,
+  ...textInputProps
+}: PlayerNameInputProps) {
   const colorScheme = useColorScheme() ?? 'light';
   const labelColor = colorScheme === 'light' ? '#1f2937' : '#e5e7eb';
   const inputTextColor = colorScheme === 'light' ? '#0f172a' : '#f8fafc';
@@ -18,8 +38,8 @@ export function PlayerNameInput({ label, errorMessage, style, ...textInputProps 
   const placeholderColor = colorScheme === 'light' ? '#94a3b8' : '#64748b';
 
   return (
-    <View style={styles.container}>
-      <Text style={[styles.label, { color: labelColor }]}>{label}</Text>
+    <View style={[styles.container, containerStyle]}>
+      <Text style={[styles.label, { color: labelColor }, labelStyle]}>{label}</Text>
       <TextInput
         placeholderTextColor={placeholderColor}
         style={[
@@ -29,7 +49,9 @@ export function PlayerNameInput({ label, errorMessage, style, ...textInputProps 
         ]}
         {...textInputProps}
       />
-      {Boolean(errorMessage) && <Text style={[styles.error, { color: errorColor }]}>{errorMessage}</Text>}
+      {Boolean(errorMessage) && (
+        <Text style={[styles.error, { color: errorColor }, errorTextStyle]}>{errorMessage}</Text>
+      )}
     </View>
   );
 }

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -139,67 +139,53 @@ export default function SetupScreen() {
             >
               <View
                 style={[
-                  styles.horizontalLine,
-                  styles.topServiceLine,
-                  { backgroundColor: courtLineColor },
-                ]}
-              />
-              <View
-                style={[
-                  styles.horizontalLine,
-                  styles.bottomServiceLine,
-                  { backgroundColor: courtLineColor },
-                ]}
-              />
-              <View
-                style={[
-                  styles.verticalLine,
-                  styles.leftServiceLine,
-                  { backgroundColor: courtLineColor },
-                ]}
-              />
-              <View
-                style={[
-                  styles.verticalLine,
-                  styles.rightServiceLine,
-                  { backgroundColor: courtLineColor },
-                ]}
-              />
-              <View
-                style={[
-                  styles.verticalLine,
-                  styles.singlesLine,
-                  styles.singlesLeft,
-                  { backgroundColor: courtLineColor },
-                ]}
-              />
-              <View
-                style={[
-                  styles.verticalLine,
-                  styles.singlesLine,
-                  styles.singlesRight,
-                  { backgroundColor: courtLineColor },
-                ]}
-              />
-              <View style={[styles.centerLine, { borderColor: courtLineColor }]} />
-
-              <View
-                style={[
-                  styles.sideContainer,
-                  styles.sideAContainer,
-                  { backgroundColor: sideContainerOverlay, borderColor: sideBorderColor },
+                  styles.playerZone,
+                  matchType === 'doubles'
+                    ? styles.playerZoneTopLeft
+                    : styles.playerZoneTopCenter,
+                  {
+                    backgroundColor: sideContainerOverlay,
+                    borderColor: sideBorderColor,
+                  },
                 ]}
               >
                 <ThemedText style={[styles.sideLabel, { color: sideLabelColor }]}>Side A</ThemedText>
-                <View style={[styles.inputSlot, matchType === 'singles' ? styles.inputSlotLast : null]}>
+                <PlayerNameInput
+                  label={matchType === 'doubles' ? 'Player 1' : 'Player'}
+                  value={playerNames.sideA[0]}
+                  onChangeText={(text) => handleNameChange('sideA', 0, text)}
+                  returnKeyType="next"
+                  autoCapitalize="words"
+                  errorMessage={
+                    showValidation && playerNames.sideA[0].trim().length === 0 ? nameError : undefined
+                  }
+                  labelStyle={[styles.inputLabel, { color: inputLabelColor }]}
+                  style={[
+                    styles.inputOnCourt,
+                    { backgroundColor: inputBackground, color: inputTextColor },
+                  ]}
+                />
+              </View>
+
+              {matchType === 'doubles' && (
+                <View
+                  style={[
+                    styles.playerZone,
+                    styles.playerZoneTopRight,
+                    {
+                      backgroundColor: sideContainerOverlay,
+                      borderColor: sideBorderColor,
+                    },
+                  ]}
+                >
                   <PlayerNameInput
-                    label={matchType === 'doubles' ? 'Player 1' : 'Player'}
-                    value={playerNames.sideA[0]}
-                    onChangeText={(text) => handleNameChange('sideA', 0, text)}
+                    label="Player 2"
+                    value={playerNames.sideA[1]}
+                    onChangeText={(text) => handleNameChange('sideA', 1, text)}
                     returnKeyType="next"
                     autoCapitalize="words"
                     errorMessage={
-                      showValidation && playerNames.sideA[0].trim().length === 0 ? nameError : undefined
+                      showValidation && playerNames.sideA[1].trim().length === 0 ? nameError : undefined
                     }
                     labelStyle={[styles.inputLabel, { color: inputLabelColor }]}
                     style={[
@@ -208,44 +194,57 @@ export default function SetupScreen() {
                     ]}
                   />
                 </View>
-                {matchType === 'doubles' && (
-                  <View style={[styles.inputSlot, styles.inputSlotLast]}>
-                    <PlayerNameInput
-                      label="Player 2"
-                      value={playerNames.sideA[1]}
-                      onChangeText={(text) => handleNameChange('sideA', 1, text)}
-                      returnKeyType="next"
-                      autoCapitalize="words"
-                      errorMessage={
-                        showValidation && playerNames.sideA[1].trim().length === 0 ? nameError : undefined
-                      }
-                      labelStyle={[styles.inputLabel, { color: inputLabelColor }]}
-                      style={[
-                        styles.inputOnCourt,
-                        { backgroundColor: inputBackground, color: inputTextColor },
-                      ]}
-                    />
-                  </View>
-                )}
-              </View>
+              )}
 
               <View
                 style={[
-                  styles.sideContainer,
-                  styles.sideBContainer,
-                  { backgroundColor: sideContainerOverlay, borderColor: sideBorderColor },
+                  styles.playerZone,
+                  matchType === 'doubles'
+                    ? styles.playerZoneBottomLeft
+                    : styles.playerZoneBottomCenter,
+                  {
+                    backgroundColor: sideContainerOverlay,
+                    borderColor: sideBorderColor,
+                  },
                 ]}
               >
                 <ThemedText style={[styles.sideLabel, { color: sideLabelColor }]}>Side B</ThemedText>
-                <View style={[styles.inputSlot, matchType === 'singles' ? styles.inputSlotLast : null]}>
+                <PlayerNameInput
+                  label={matchType === 'doubles' ? 'Player 1' : 'Player'}
+                  value={playerNames.sideB[0]}
+                  onChangeText={(text) => handleNameChange('sideB', 0, text)}
+                  returnKeyType={matchType === 'doubles' ? 'next' : 'done'}
+                  autoCapitalize="words"
+                  errorMessage={
+                    showValidation && playerNames.sideB[0].trim().length === 0 ? nameError : undefined
+                  }
+                  labelStyle={[styles.inputLabel, { color: inputLabelColor }]}
+                  style={[
+                    styles.inputOnCourt,
+                    { backgroundColor: inputBackground, color: inputTextColor },
+                  ]}
+                />
+              </View>
+
+              {matchType === 'doubles' && (
+                <View
+                  style={[
+                    styles.playerZone,
+                    styles.playerZoneBottomRight,
+                    {
+                      backgroundColor: sideContainerOverlay,
+                      borderColor: sideBorderColor,
+                    },
+                  ]}
+                >
                   <PlayerNameInput
-                    label={matchType === 'doubles' ? 'Player 1' : 'Player'}
-                    value={playerNames.sideB[0]}
-                    onChangeText={(text) => handleNameChange('sideB', 0, text)}
-                    returnKeyType="next"
+                    label="Player 2"
+                    value={playerNames.sideB[1]}
+                    onChangeText={(text) => handleNameChange('sideB', 1, text)}
+                    returnKeyType="done"
                     autoCapitalize="words"
                     errorMessage={
-                      showValidation && playerNames.sideB[0].trim().length === 0 ? nameError : undefined
+                      showValidation && playerNames.sideB[1].trim().length === 0 ? nameError : undefined
                     }
                     labelStyle={[styles.inputLabel, { color: inputLabelColor }]}
                     style={[
@@ -254,25 +253,16 @@ export default function SetupScreen() {
                     ]}
                   />
                 </View>
-                {matchType === 'doubles' && (
-                  <View style={[styles.inputSlot, styles.inputSlotLast]}>
-                    <PlayerNameInput
-                      label="Player 2"
-                      value={playerNames.sideB[1]}
-                      onChangeText={(text) => handleNameChange('sideB', 1, text)}
-                      returnKeyType="done"
-                      autoCapitalize="words"
-                      errorMessage={
-                        showValidation && playerNames.sideB[1].trim().length === 0 ? nameError : undefined
-                      }
-                      labelStyle={[styles.inputLabel, { color: inputLabelColor }]}
-                      style={[
-                        styles.inputOnCourt,
-                        { backgroundColor: inputBackground, color: inputTextColor },
-                      ]}
-                    />
-                  </View>
-                )}
+              )}
+
+              <View pointerEvents="none" style={styles.courtLineLayer}>
+                <View style={[styles.courtOutline, { borderColor: courtLineColor }]} />
+                <View style={[styles.netLine, { backgroundColor: courtLineColor }]} />
+                <View style={[styles.midCourtLine, { backgroundColor: courtLineColor }]} />
+                <View style={[styles.serviceLineTop, { backgroundColor: courtLineColor }]} />
+                <View style={[styles.serviceLineBottom, { backgroundColor: courtLineColor }]} />
+                <View style={[styles.singlesBoundaryLeft, { backgroundColor: courtLineColor }]} />
+                <View style={[styles.singlesBoundaryRight, { backgroundColor: courtLineColor }]} />
               </View>
             </View>
           </View>
@@ -380,64 +370,98 @@ const styles = StyleSheet.create({
     position: 'relative',
     overflow: 'hidden',
   },
-  horizontalLine: {
+  courtLineLayer: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 2,
+  },
+  courtOutline: {
     position: 'absolute',
-    left: '8%',
-    right: '8%',
-    height: 3,
+    top: '6%',
+    bottom: '6%',
+    left: '6%',
+    right: '6%',
+    borderWidth: 2,
+    borderRadius: 20,
   },
-  topServiceLine: {
-    top: '26%',
-  },
-  bottomServiceLine: {
-    bottom: '26%',
-  },
-  verticalLine: {
+  netLine: {
     position: 'absolute',
-    top: '16%',
-    bottom: '16%',
+    left: '6%',
+    right: '6%',
+    top: '50%',
+    height: 4,
+  },
+  midCourtLine: {
+    position: 'absolute',
+    top: '6%',
+    bottom: '6%',
+    left: '50%',
     width: 3,
   },
-  leftServiceLine: {
-    left: '28%',
+  serviceLineTop: {
+    position: 'absolute',
+    left: '6%',
+    right: '6%',
+    top: '28%',
+    height: 3,
   },
-  rightServiceLine: {
-    right: '28%',
+  serviceLineBottom: {
+    position: 'absolute',
+    left: '6%',
+    right: '6%',
+    bottom: '28%',
+    height: 3,
   },
-  singlesLine: {
-    top: '8%',
-    bottom: '8%',
+  singlesBoundaryLeft: {
+    position: 'absolute',
+    top: '6%',
+    bottom: '6%',
+    left: '22%',
     width: 2,
   },
-  singlesLeft: {
-    left: '18%',
-  },
-  singlesRight: {
-    right: '18%',
-  },
-  centerLine: {
+  singlesBoundaryRight: {
     position: 'absolute',
-    top: '8%',
-    bottom: '8%',
-    left: '50%',
-    borderLeftWidth: 3,
-    borderStyle: 'dashed',
+    top: '6%',
+    bottom: '6%',
+    right: '22%',
+    width: 2,
   },
-  sideContainer: {
+  playerZone: {
     position: 'absolute',
-    width: '40%',
-    top: '12%',
-    bottom: '12%',
     padding: 16,
     borderRadius: 18,
     borderWidth: 1,
     justifyContent: 'center',
+    zIndex: 1,
   },
-  sideAContainer: {
-    left: '6%',
+  playerZoneTopLeft: {
+    top: '10%',
+    left: '8%',
+    width: '38%',
   },
-  sideBContainer: {
-    right: '6%',
+  playerZoneTopRight: {
+    top: '10%',
+    right: '8%',
+    width: '38%',
+  },
+  playerZoneBottomLeft: {
+    bottom: '10%',
+    left: '8%',
+    width: '38%',
+  },
+  playerZoneBottomRight: {
+    bottom: '10%',
+    right: '8%',
+    width: '38%',
+  },
+  playerZoneTopCenter: {
+    top: '12%',
+    left: '14%',
+    right: '14%',
+  },
+  playerZoneBottomCenter: {
+    bottom: '12%',
+    left: '14%',
+    right: '14%',
   },
   sideLabel: {
     fontSize: 18,
@@ -445,12 +469,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     letterSpacing: 1.2,
     marginBottom: 12,
-  },
-  inputSlot: {
-    marginBottom: 14,
-  },
-  inputSlotLast: {
-    marginBottom: 0,
   },
   inputLabel: {
     textTransform: 'uppercase',

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -33,6 +33,16 @@ export default function SetupScreen() {
   const [matchType, setMatchType] = useState<MatchType>('singles');
   const [playerNames, setPlayerNames] = useState<PlayerNamesState>(initialPlayerNames);
   const [showValidation, setShowValidation] = useState(false);
+  const colorScheme = useColorScheme() ?? 'light';
+
+  const courtBackground = colorScheme === 'light' ? '#0a8f3d' : '#064e3b';
+  const courtLineColor = '#f8fafc';
+  const sideContainerOverlay = colorScheme === 'light' ? 'rgba(255,255,255,0.14)' : 'rgba(15,23,42,0.4)';
+  const sideBorderColor = colorScheme === 'light' ? 'rgba(255,255,255,0.4)' : 'rgba(226,232,240,0.5)';
+  const sideLabelColor = colorScheme === 'light' ? '#f8fafc' : '#e0f2fe';
+  const inputBackground = colorScheme === 'light' ? 'rgba(255,255,255,0.92)' : 'rgba(15,23,42,0.92)';
+  const inputTextColor = colorScheme === 'light' ? '#0f172a' : '#f8fafc';
+  const inputLabelColor = colorScheme === 'light' ? '#065f46' : '#bfdbfe';
 
   const requiredNames = useMemo(() => {
     if (matchType === 'singles') {
@@ -88,7 +98,7 @@ export default function SetupScreen() {
   const nameError = showValidation ? 'Please enter a name' : undefined;
 
   return (
-    <ThemedView style={styles.container}>
+    <ThemedView style={styles.container} lightColor={courtBackground} darkColor={courtBackground}>
       <KeyboardAvoidingView
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
         style={styles.flexContainer}
@@ -98,7 +108,7 @@ export default function SetupScreen() {
             Match Setup
           </ThemedText>
 
-          <View style={styles.section}>
+          <View style={styles.matchTypeSection}>
             <ThemedText type="subtitle" style={styles.sectionTitle}>
               Match Type
             </ThemedText>
@@ -117,71 +127,153 @@ export default function SetupScreen() {
             </View>
           </View>
 
-          <View style={styles.section}>
-            <ThemedText type="subtitle" style={styles.sectionTitle}>
-              Side A
-            </ThemedText>
-            <View>
-              <View style={styles.inputWrapper}>
-                <PlayerNameInput
-                  label={matchType === 'doubles' ? 'Player 1' : 'Player'}
-                  value={playerNames.sideA[0]}
-                  onChangeText={(text) => handleNameChange('sideA', 0, text)}
-                  returnKeyType="next"
-                  autoCapitalize="words"
-                  errorMessage={
-                    showValidation && playerNames.sideA[0].trim().length === 0 ? nameError : undefined
-                  }
-                />
-              </View>
-              {matchType === 'doubles' && (
-                <View style={styles.inputWrapper}>
+          <View style={styles.courtWrapper}>
+            <View
+              style={[
+                styles.court,
+                {
+                  borderColor: courtLineColor,
+                  backgroundColor: courtBackground,
+                },
+              ]}
+            >
+              <View
+                style={[
+                  styles.horizontalLine,
+                  styles.topServiceLine,
+                  { backgroundColor: courtLineColor },
+                ]}
+              />
+              <View
+                style={[
+                  styles.horizontalLine,
+                  styles.bottomServiceLine,
+                  { backgroundColor: courtLineColor },
+                ]}
+              />
+              <View
+                style={[
+                  styles.verticalLine,
+                  styles.leftServiceLine,
+                  { backgroundColor: courtLineColor },
+                ]}
+              />
+              <View
+                style={[
+                  styles.verticalLine,
+                  styles.rightServiceLine,
+                  { backgroundColor: courtLineColor },
+                ]}
+              />
+              <View
+                style={[
+                  styles.verticalLine,
+                  styles.singlesLine,
+                  styles.singlesLeft,
+                  { backgroundColor: courtLineColor },
+                ]}
+              />
+              <View
+                style={[
+                  styles.verticalLine,
+                  styles.singlesLine,
+                  styles.singlesRight,
+                  { backgroundColor: courtLineColor },
+                ]}
+              />
+              <View style={[styles.centerLine, { borderColor: courtLineColor }]} />
+
+              <View
+                style={[
+                  styles.sideContainer,
+                  styles.sideAContainer,
+                  { backgroundColor: sideContainerOverlay, borderColor: sideBorderColor },
+                ]}
+              >
+                <ThemedText style={[styles.sideLabel, { color: sideLabelColor }]}>Side A</ThemedText>
+                <View style={[styles.inputSlot, matchType === 'singles' ? styles.inputSlotLast : null]}>
                   <PlayerNameInput
-                    label="Player 2"
-                    value={playerNames.sideA[1]}
-                    onChangeText={(text) => handleNameChange('sideA', 1, text)}
+                    label={matchType === 'doubles' ? 'Player 1' : 'Player'}
+                    value={playerNames.sideA[0]}
+                    onChangeText={(text) => handleNameChange('sideA', 0, text)}
                     returnKeyType="next"
                     autoCapitalize="words"
                     errorMessage={
-                      showValidation && playerNames.sideA[1].trim().length === 0 ? nameError : undefined
+                      showValidation && playerNames.sideA[0].trim().length === 0 ? nameError : undefined
                     }
+                    labelStyle={[styles.inputLabel, { color: inputLabelColor }]}
+                    style={[
+                      styles.inputOnCourt,
+                      { backgroundColor: inputBackground, color: inputTextColor },
+                    ]}
                   />
                 </View>
-              )}
-            </View>
-          </View>
-
-          <View style={styles.section}>
-            <ThemedText type="subtitle" style={styles.sectionTitle}>
-              Side B
-            </ThemedText>
-            <View>
-              <View style={styles.inputWrapper}>
-                <PlayerNameInput
-                  label={matchType === 'doubles' ? 'Player 1' : 'Player'}
-                  value={playerNames.sideB[0]}
-                  onChangeText={(text) => handleNameChange('sideB', 0, text)}
-                  returnKeyType="next"
-                  autoCapitalize="words"
-                  errorMessage={
-                    showValidation && playerNames.sideB[0].trim().length === 0 ? nameError : undefined
-                  }
-                />
+                {matchType === 'doubles' && (
+                  <View style={[styles.inputSlot, styles.inputSlotLast]}>
+                    <PlayerNameInput
+                      label="Player 2"
+                      value={playerNames.sideA[1]}
+                      onChangeText={(text) => handleNameChange('sideA', 1, text)}
+                      returnKeyType="next"
+                      autoCapitalize="words"
+                      errorMessage={
+                        showValidation && playerNames.sideA[1].trim().length === 0 ? nameError : undefined
+                      }
+                      labelStyle={[styles.inputLabel, { color: inputLabelColor }]}
+                      style={[
+                        styles.inputOnCourt,
+                        { backgroundColor: inputBackground, color: inputTextColor },
+                      ]}
+                    />
+                  </View>
+                )}
               </View>
-              {matchType === 'doubles' && (
-                <View style={styles.inputWrapper}>
+
+              <View
+                style={[
+                  styles.sideContainer,
+                  styles.sideBContainer,
+                  { backgroundColor: sideContainerOverlay, borderColor: sideBorderColor },
+                ]}
+              >
+                <ThemedText style={[styles.sideLabel, { color: sideLabelColor }]}>Side B</ThemedText>
+                <View style={[styles.inputSlot, matchType === 'singles' ? styles.inputSlotLast : null]}>
                   <PlayerNameInput
-                    label="Player 2"
-                    value={playerNames.sideB[1]}
-                    onChangeText={(text) => handleNameChange('sideB', 1, text)}
-                    returnKeyType="done"
+                    label={matchType === 'doubles' ? 'Player 1' : 'Player'}
+                    value={playerNames.sideB[0]}
+                    onChangeText={(text) => handleNameChange('sideB', 0, text)}
+                    returnKeyType="next"
                     autoCapitalize="words"
                     errorMessage={
-                      showValidation && playerNames.sideB[1].trim().length === 0 ? nameError : undefined
+                      showValidation && playerNames.sideB[0].trim().length === 0 ? nameError : undefined
                     }
+                    labelStyle={[styles.inputLabel, { color: inputLabelColor }]}
+                    style={[
+                      styles.inputOnCourt,
+                      { backgroundColor: inputBackground, color: inputTextColor },
+                    ]}
                   />
                 </View>
-              )}
+                {matchType === 'doubles' && (
+                  <View style={[styles.inputSlot, styles.inputSlotLast]}>
+                    <PlayerNameInput
+                      label="Player 2"
+                      value={playerNames.sideB[1]}
+                      onChangeText={(text) => handleNameChange('sideB', 1, text)}
+                      returnKeyType="done"
+                      autoCapitalize="words"
+                      errorMessage={
+                        showValidation && playerNames.sideB[1].trim().length === 0 ? nameError : undefined
+                      }
+                      labelStyle={[styles.inputLabel, { color: inputLabelColor }]}
+                      style={[
+                        styles.inputOnCourt,
+                        { backgroundColor: inputBackground, color: inputTextColor },
+                      ]}
+                    />
+                  </View>
+                )}
+              </View>
             </View>
           </View>
         </ScrollView>
@@ -244,35 +336,133 @@ function MatchTypeToggle({ label, isActive, onPress, style }: MatchTypeTogglePro
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    paddingHorizontal: 24,
-    paddingVertical: 32,
+    paddingHorizontal: 16,
+    paddingVertical: 24,
   },
   flexContainer: {
     flex: 1,
   },
   scrollContainer: {
-    paddingBottom: 32,
+    paddingBottom: 40,
+    alignItems: 'center',
   },
   heading: {
     marginBottom: 24,
+    textAlign: 'center',
   },
-  section: {
+  matchTypeSection: {
+    width: '100%',
+    maxWidth: 520,
     marginBottom: 24,
   },
   sectionTitle: {
     marginBottom: 12,
+    textAlign: 'center',
   },
   matchTypeRow: {
     flexDirection: 'row',
+    justifyContent: 'center',
   },
   matchTypeToggleSpacing: {
     marginRight: 12,
   },
-  inputWrapper: {
-    marginBottom: 16,
+  courtWrapper: {
+    width: '100%',
+    alignItems: 'center',
+    marginBottom: 32,
+  },
+  court: {
+    width: '100%',
+    maxWidth: 520,
+    aspectRatio: 13 / 6,
+    borderRadius: 28,
+    borderWidth: 6,
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  horizontalLine: {
+    position: 'absolute',
+    left: '8%',
+    right: '8%',
+    height: 3,
+  },
+  topServiceLine: {
+    top: '26%',
+  },
+  bottomServiceLine: {
+    bottom: '26%',
+  },
+  verticalLine: {
+    position: 'absolute',
+    top: '16%',
+    bottom: '16%',
+    width: 3,
+  },
+  leftServiceLine: {
+    left: '28%',
+  },
+  rightServiceLine: {
+    right: '28%',
+  },
+  singlesLine: {
+    top: '8%',
+    bottom: '8%',
+    width: 2,
+  },
+  singlesLeft: {
+    left: '18%',
+  },
+  singlesRight: {
+    right: '18%',
+  },
+  centerLine: {
+    position: 'absolute',
+    top: '8%',
+    bottom: '8%',
+    left: '50%',
+    borderLeftWidth: 3,
+    borderStyle: 'dashed',
+  },
+  sideContainer: {
+    position: 'absolute',
+    width: '40%',
+    top: '12%',
+    bottom: '12%',
+    padding: 16,
+    borderRadius: 18,
+    borderWidth: 1,
+    justifyContent: 'center',
+  },
+  sideAContainer: {
+    left: '6%',
+  },
+  sideBContainer: {
+    right: '6%',
+  },
+  sideLabel: {
+    fontSize: 18,
+    fontWeight: '700',
+    textAlign: 'center',
+    letterSpacing: 1.2,
+    marginBottom: 12,
+  },
+  inputSlot: {
+    marginBottom: 14,
+  },
+  inputSlotLast: {
+    marginBottom: 0,
+  },
+  inputLabel: {
+    textTransform: 'uppercase',
+    fontSize: 12,
+    fontWeight: '600',
+    letterSpacing: 1,
+  },
+  inputOnCourt: {
+    borderWidth: 0,
   },
   footer: {
-    paddingTop: 12,
+    paddingTop: 16,
   },
   validationMessage: {
     color: '#ef4444',

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   Text,
   View,
+  useWindowDimensions,
 } from 'react-native';
 import type { StyleProp, ViewStyle } from 'react-native';
 
@@ -34,6 +35,7 @@ export default function SetupScreen() {
   const [playerNames, setPlayerNames] = useState<PlayerNamesState>(initialPlayerNames);
   const [showValidation, setShowValidation] = useState(false);
   const colorScheme = useColorScheme() ?? 'light';
+  const { width: screenWidth, height: screenHeight } = useWindowDimensions();
 
   const courtBackground = colorScheme === 'light' ? '#0a8f3d' : '#064e3b';
   const courtLineColor = '#f8fafc';
@@ -97,6 +99,23 @@ export default function SetupScreen() {
 
   const nameError = showValidation ? 'Please enter a name' : undefined;
 
+  const courtDimensions = useMemo(() => {
+    const horizontalPadding = 32; // container padding (16 left + 16 right)
+    const aspectRatio = 13 / 6;
+    const availableWidth = Math.max(screenWidth - horizontalPadding, 320);
+    const maxCourtHeight = Math.max(screenHeight * 0.7, 320);
+
+    let computedWidth = availableWidth;
+    let computedHeight = computedWidth / aspectRatio;
+
+    if (computedHeight > maxCourtHeight) {
+      computedHeight = maxCourtHeight;
+      computedWidth = computedHeight * aspectRatio;
+    }
+
+    return { width: computedWidth, height: computedHeight };
+  }, [screenHeight, screenWidth]);
+
   return (
     <ThemedView style={styles.container} lightColor={courtBackground} darkColor={courtBackground}>
       <KeyboardAvoidingView
@@ -131,6 +150,7 @@ export default function SetupScreen() {
             <View
               style={[
                 styles.court,
+                courtDimensions,
                 {
                   borderColor: courtLineColor,
                   backgroundColor: courtBackground,
@@ -333,6 +353,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   scrollContainer: {
+    flexGrow: 1,
     paddingBottom: 40,
     alignItems: 'center',
   },
@@ -363,8 +384,6 @@ const styles = StyleSheet.create({
   },
   court: {
     width: '100%',
-    maxWidth: 520,
-    aspectRatio: 13 / 6,
     borderRadius: 28,
     borderWidth: 6,
     position: 'relative',


### PR DESCRIPTION
## Summary
- restyle the match setup screen to render player name inputs directly on a stylized badminton court
- add styling overrides to the shared player name input component for better visual integration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e244275d508320a8b2650b94a840b4