### PR TITLE
Add GitHub Pages deployment workflow for Expo web build

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,57 @@
+name: Deploy Expo Web to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-web
+  cancel-in-progress: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Determine base URL
+        id: base
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          if [ "$REPO_NAME" = "${GITHUB_REPOSITORY_OWNER}.github.io" ]; then
+            echo "base_url=https://${GITHUB_REPOSITORY_OWNER}.github.io" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_url=https://${GITHUB_REPOSITORY_OWNER}.github.io/${REPO_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build static web bundle
+        env:
+          EXPO_NO_DEBUG: "1"
+          EXPO_USE_STATIC: "1"
+          EXPO_NO_TELEMETRY: "1"
+          EXPO_PUBLIC_BASE_URL: ${{ steps.base.outputs.base_url }}
+        run: npx expo export --platform web --output-dir dist
+
+      - name: Prepare Pages artifacts
+        run: touch dist/.nojekyll
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          publish_branch: gh-pages


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Expo web bundle and publishes it to GitHub Pages
- configure the workflow to detect the appropriate GitHub Pages base URL and deploy to the gh-pages branch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24b37232483208d2c2b4812dd19d4