### PR TITLE
Implement badminton match flow rules

### DIFF
--- a/src/screens/ScoreboardScreen.tsx
+++ b/src/screens/ScoreboardScreen.tsx
@@ -12,7 +12,6 @@ import { ThemedText } from '#/components/themed-text';
 import { ThemedView } from '#/components/themed-view';
 import { useColorScheme } from '#/hooks/use-color-scheme';
 import { useMatch } from '#/state/MatchContext';
-import type { TeamId } from '#/types/match';
 
 export default function ScoreboardScreen() {
   const router = useRouter();
@@ -29,8 +28,8 @@ export default function ScoreboardScreen() {
   }, [matchInProgress, router]);
 
   const orderedTeams = useMemo(
-    () => (['sideA', 'sideB'] as TeamId[]).map((id) => matchState.teams[id]),
-    [matchState.teams],
+    () => matchState.courtOrder.map((id) => matchState.teams[id]),
+    [matchState.courtOrder, matchState.teams],
   );
 
   if (!matchInProgress) {

--- a/src/state/MatchContext.tsx
+++ b/src/state/MatchContext.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react';
 
 import type { MatchType, TeamId } from '#/types/match';
 
+type MatchStatus = 'idle' | 'in-progress' | 'completed';
+
 type TeamState = {
   id: TeamId;
   label: string;
@@ -10,19 +12,29 @@ type TeamState = {
   score: number;
 };
 
+type CourtOrder = [TeamId, TeamId];
+
 type ScoreSnapshot = {
   scores: Record<TeamId, number>;
   servingTeam: TeamId;
+  currentGame: number;
+  gamesWon: Record<TeamId, number>;
+  status: MatchStatus;
+  courtOrder: CourtOrder;
+  hasSwitchedMidGame: boolean;
 };
 
 type MatchState = {
-  status: 'idle' | 'in-progress';
+  status: MatchStatus;
   matchTitle: string;
   matchType: MatchType;
   currentGame: number;
   totalGames: number;
   venueName?: string;
   servingTeam: TeamId;
+  gamesWon: Record<TeamId, number>;
+  courtOrder: CourtOrder;
+  hasSwitchedMidGame: boolean;
   teams: Record<TeamId, TeamState>;
   history: ScoreSnapshot[];
 };
@@ -55,6 +67,12 @@ const initialState: MatchState = {
   currentGame: 1,
   totalGames: 3,
   servingTeam: 'sideA',
+  gamesWon: {
+    sideA: 0,
+    sideB: 0,
+  },
+  courtOrder: ['sideA', 'sideB'],
+  hasSwitchedMidGame: false,
   teams: {
     sideA: defaultTeamState('sideA', 'Side A'),
     sideB: defaultTeamState('sideB', 'Side B'),
@@ -88,6 +106,12 @@ export function MatchProvider({ children }: { children: ReactNode }) {
       currentGame: 1,
       totalGames: 3,
       servingTeam: 'sideA',
+      gamesWon: {
+        sideA: 0,
+        sideB: 0,
+      },
+      courtOrder: ['sideA', 'sideB'],
+      hasSwitchedMidGame: false,
       teams: {
         sideA: {
           id: 'sideA',
@@ -118,18 +142,96 @@ export function MatchProvider({ children }: { children: ReactNode }) {
           sideB: current.teams.sideB.score,
         },
         servingTeam: current.servingTeam,
+        currentGame: current.currentGame,
+        gamesWon: {
+          sideA: current.gamesWon.sideA,
+          sideB: current.gamesWon.sideB,
+        },
+        status: current.status,
+        courtOrder: [...current.courtOrder],
+        hasSwitchedMidGame: current.hasSwitchedMidGame,
       };
+
+      const opponentId: TeamId = teamId === 'sideA' ? 'sideB' : 'sideA';
+
+      const updatedScores: Record<TeamId, number> = {
+        sideA:
+          teamId === 'sideA' ? current.teams.sideA.score + 1 : current.teams.sideA.score,
+        sideB:
+          teamId === 'sideB' ? current.teams.sideB.score + 1 : current.teams.sideB.score,
+      };
+
+      let nextCourtOrder: CourtOrder = current.courtOrder;
+      let hasSwitchedMidGame = current.hasSwitchedMidGame;
+
+      if (
+        !current.hasSwitchedMidGame &&
+        current.currentGame === current.totalGames &&
+        (updatedScores.sideA === 11 || updatedScores.sideB === 11)
+      ) {
+        nextCourtOrder = [current.courtOrder[1], current.courtOrder[0]];
+        hasSwitchedMidGame = true;
+      }
+
+      const winnerScore = updatedScores[teamId];
+      const opponentScore = updatedScores[opponentId];
+      const hasTwoPointLead = winnerScore >= 21 && winnerScore - opponentScore >= 2;
+      const reachedMaxPoint = winnerScore === 30;
+      const gameWon = hasTwoPointLead || reachedMaxPoint;
+
+      let currentGame = current.currentGame;
+      let gamesWon = { ...current.gamesWon };
+      let servingTeam: TeamId = teamId;
+      let status: MatchState['status'] = current.status;
+      let teams: Record<TeamId, TeamState> = {
+        sideA: {
+          ...current.teams.sideA,
+          score: updatedScores.sideA,
+        },
+        sideB: {
+          ...current.teams.sideB,
+          score: updatedScores.sideB,
+        },
+      };
+
+      if (gameWon) {
+        gamesWon = {
+          ...gamesWon,
+          [teamId]: gamesWon[teamId] + 1,
+        };
+
+        const gamesNeededToWin = Math.floor(current.totalGames / 2) + 1;
+        const matchWon = gamesWon[teamId] >= gamesNeededToWin;
+
+        if (matchWon) {
+          status = 'completed';
+        } else {
+          currentGame = current.currentGame + 1;
+          servingTeam = teamId;
+          teams = {
+            sideA: {
+              ...teams.sideA,
+              score: 0,
+            },
+            sideB: {
+              ...teams.sideB,
+              score: 0,
+            },
+          };
+          nextCourtOrder = [current.courtOrder[1], current.courtOrder[0]];
+          hasSwitchedMidGame = false;
+        }
+      }
 
       return {
         ...current,
-        teams: {
-          ...current.teams,
-          [teamId]: {
-            ...current.teams[teamId],
-            score: current.teams[teamId].score + 1,
-          },
-        },
-        servingTeam: teamId,
+        teams,
+        servingTeam,
+        currentGame,
+        gamesWon,
+        status,
+        courtOrder: nextCourtOrder,
+        hasSwitchedMidGame,
         history: [...current.history, snapshot],
       };
     });
@@ -137,7 +239,7 @@ export function MatchProvider({ children }: { children: ReactNode }) {
 
   const undoLastPoint = useCallback(() => {
     setMatchState((current) => {
-      if (current.status !== 'in-progress' || current.history.length === 0) {
+      if (current.history.length === 0) {
         return current;
       }
 
@@ -157,6 +259,14 @@ export function MatchProvider({ children }: { children: ReactNode }) {
           },
         },
         servingTeam: previousSnapshot.servingTeam,
+        currentGame: previousSnapshot.currentGame,
+        gamesWon: {
+          sideA: previousSnapshot.gamesWon.sideA,
+          sideB: previousSnapshot.gamesWon.sideB,
+        },
+        status: previousSnapshot.status,
+        courtOrder: previousSnapshot.courtOrder,
+        hasSwitchedMidGame: previousSnapshot.hasSwitchedMidGame,
         history: nextHistory,
       };
     });


### PR DESCRIPTION
## Summary
- add match state tracking for game wins, court order, and match completion
- implement point handling with badminton rules including 11-point side switches and best-of-three logic
- update the scoreboard to respect dynamic court order when rendering teams

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2593d24708320a652dde1cd10675e