### PR TITLE
Wire scoreboard screen to Redux state

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,20 +3,22 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
+import { Provider } from 'react-redux';
+
 import { useColorScheme } from '#/hooks/use-color-scheme';
-import { MatchProvider } from '#/state/MatchContext';
+import { store } from '#/redux/store';
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <MatchProvider>
+      <Provider store={store}>
         <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="index" />
           <Stack.Screen name="scoreboard" />
         </Stack>
-      </MatchProvider>
+      </Provider>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
     </ThemeProvider>
   );

--- a/src/redux/hooks.ts
+++ b/src/redux/hooks.ts
@@ -1,0 +1,7 @@
+import { useDispatch, useSelector } from 'react-redux';
+import type { TypedUseSelectorHook } from 'react-redux';
+
+import type { AppDispatch, RootState } from './store';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/src/redux/matchSlice.ts
+++ b/src/redux/matchSlice.ts
@@ -1,0 +1,140 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { PayloadAction } from '@reduxjs/toolkit';
+
+import type { MatchType, TeamId } from '#/types/match';
+import type { RootState } from './store';
+
+export type TeamState = {
+  id: TeamId;
+  label: string;
+  players: string[];
+  score: number;
+};
+
+export type ScoreSnapshot = {
+  scores: Record<TeamId, number>;
+  servingTeam: TeamId;
+};
+
+export type PlayerNameEntries = Record<TeamId, [string, string]>;
+
+export type MatchStatus = 'idle' | 'in-progress';
+
+export type MatchState = {
+  status: MatchStatus;
+  matchTitle: string;
+  matchType: MatchType;
+  currentGame: number;
+  totalGames: number;
+  venueName?: string;
+  servingTeam: TeamId;
+  teams: Record<TeamId, TeamState>;
+  history: ScoreSnapshot[];
+};
+
+export type StartMatchPayload = {
+  matchType: MatchType;
+  playerNames: PlayerNameEntries;
+};
+
+const defaultTeamState = (id: TeamId, label: string): TeamState => ({
+  id,
+  label,
+  players: [],
+  score: 0,
+});
+
+const initialState: MatchState = {
+  status: 'idle',
+  matchTitle: 'Friendly Match',
+  matchType: 'singles',
+  currentGame: 1,
+  totalGames: 3,
+  servingTeam: 'sideA',
+  teams: {
+    sideA: defaultTeamState('sideA', 'Side A'),
+    sideB: defaultTeamState('sideB', 'Side B'),
+  },
+  history: [],
+};
+
+const sanitizeNames = (names: [string, string]) =>
+  names.map((name) => name.trim()).filter((name) => name.length > 0);
+
+const matchSlice = createSlice({
+  name: 'match',
+  initialState,
+  reducers: {
+    startMatch(state, action: PayloadAction<StartMatchPayload>) {
+      const { matchType, playerNames } = action.payload;
+
+      const sideAPlayers =
+        matchType === 'singles'
+          ? sanitizeNames([playerNames.sideA[0], '']).slice(0, 1)
+          : sanitizeNames(playerNames.sideA);
+
+      const sideBPlayers =
+        matchType === 'singles'
+          ? sanitizeNames([playerNames.sideB[0], '']).slice(0, 1)
+          : sanitizeNames(playerNames.sideB);
+
+      state.status = 'in-progress';
+      state.matchType = matchType;
+      state.currentGame = 1;
+      state.totalGames = 3;
+      state.servingTeam = 'sideA';
+      state.history = [];
+      state.teams.sideA = {
+        id: 'sideA',
+        label: 'Side A',
+        players: sideAPlayers,
+        score: 0,
+      };
+      state.teams.sideB = {
+        id: 'sideB',
+        label: 'Side B',
+        players: sideBPlayers,
+        score: 0,
+      };
+    },
+    addPoint(state, action: PayloadAction<TeamId>) {
+      if (state.status !== 'in-progress') {
+        return;
+      }
+
+      const teamId = action.payload;
+      const snapshot: ScoreSnapshot = {
+        scores: {
+          sideA: state.teams.sideA.score,
+          sideB: state.teams.sideB.score,
+        },
+        servingTeam: state.servingTeam,
+      };
+
+      state.history.push(snapshot);
+      state.teams[teamId].score += 1;
+      state.servingTeam = teamId;
+    },
+    undoLastPoint(state) {
+      if (state.status !== 'in-progress' || state.history.length === 0) {
+        return;
+      }
+
+      const previousSnapshot = state.history.pop();
+
+      if (!previousSnapshot) {
+        return;
+      }
+
+      state.teams.sideA.score = previousSnapshot.scores.sideA;
+      state.teams.sideB.score = previousSnapshot.scores.sideB;
+      state.servingTeam = previousSnapshot.servingTeam;
+    },
+  },
+});
+
+export const { startMatch, addPoint, undoLastPoint } = matchSlice.actions;
+
+export const selectMatch = (state: RootState) => state.match;
+
+export default matchSlice.reducer;

--- a/src/redux/matchSlice.ts
+++ b/src/redux/matchSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSelector, createSlice } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
 
 import type { MatchType, TeamId } from '#/types/match';
@@ -136,5 +136,16 @@ const matchSlice = createSlice({
 export const { startMatch, addPoint, undoLastPoint } = matchSlice.actions;
 
 export const selectMatch = (state: RootState) => state.match;
+
+export const selectIsMatchInProgress = createSelector(
+  selectMatch,
+  (match) => match.status === 'in-progress',
+);
+
+export const selectCanUndo = createSelector(selectMatch, (match) => match.history.length > 0);
+
+export const selectOrderedTeams = createSelector(selectMatch, (match) =>
+  (['sideA', 'sideB'] as TeamId[]).map((id) => match.teams[id]),
+);
 
 export default matchSlice.reducer;

--- a/src/redux/matchSlice.ts
+++ b/src/redux/matchSlice.ts
@@ -11,6 +11,25 @@ export type TeamState = {
   score: number;
 };
 
+export type ScoreboardTeam = {
+  id: TeamId;
+  label: string;
+  score: number;
+  isServing: boolean;
+  playerLabel: string;
+};
+
+export type ScoreboardViewModel = {
+  matchInProgress: boolean;
+  matchTitle: string;
+  matchTypeLabel: 'Singles' | 'Doubles';
+  currentGame: number;
+  totalGames: number;
+  venueName?: string;
+  canUndo: boolean;
+  teams: ScoreboardTeam[];
+};
+
 export type ScoreSnapshot = {
   scores: Record<TeamId, number>;
   servingTeam: TeamId;
@@ -146,6 +165,32 @@ export const selectCanUndo = createSelector(selectMatch, (match) => match.histor
 
 export const selectOrderedTeams = createSelector(selectMatch, (match) =>
   (['sideA', 'sideB'] as TeamId[]).map((id) => match.teams[id]),
+);
+
+const selectScoreboardTeams = createSelector(
+  [selectOrderedTeams, selectMatch],
+  (teams, match): ScoreboardTeam[] =>
+    teams.map((team) => ({
+      id: team.id,
+      label: team.label,
+      score: team.score,
+      isServing: match.servingTeam === team.id,
+      playerLabel: team.players.length > 0 ? team.players.join(' & ') : 'Ready to Play',
+    })),
+);
+
+export const selectScoreboardViewModel = createSelector(
+  [selectMatch, selectScoreboardTeams],
+  (match, teams): ScoreboardViewModel => ({
+    matchInProgress: match.status === 'in-progress',
+    matchTitle: match.matchTitle,
+    matchTypeLabel: match.matchType === 'singles' ? 'Singles' : 'Doubles',
+    currentGame: match.currentGame,
+    totalGames: match.totalGames,
+    venueName: match.venueName,
+    canUndo: match.history.length > 0,
+    teams,
+  }),
 );
 
 export default matchSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+import matchReducer from './matchSlice';
+
+export const store = configureStore({
+  reducer: {
+    match: matchReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/src/screens/ScoreboardScreen.tsx
+++ b/src/screens/ScoreboardScreen.tsx
@@ -12,26 +12,32 @@ import { ThemedText } from '#/components/themed-text';
 import { ThemedView } from '#/components/themed-view';
 import { useColorScheme } from '#/hooks/use-color-scheme';
 import { useAppDispatch, useAppSelector } from '#/redux/hooks';
-import { addPoint, selectMatch, undoLastPoint } from '#/redux/matchSlice';
+import {
+  addPoint,
+  selectCanUndo,
+  selectIsMatchInProgress,
+  selectMatch,
+  selectOrderedTeams,
+  undoLastPoint,
+} from '#/redux/matchSlice';
 import type { TeamId } from '#/types/match';
 
 export default function ScoreboardScreen() {
   const router = useRouter();
   const dispatch = useAppDispatch();
   const matchState = useAppSelector(selectMatch);
+  const orderedTeams = useAppSelector(selectOrderedTeams);
+  const matchInProgress = useAppSelector(selectIsMatchInProgress);
+  const canUndo = useAppSelector(selectCanUndo);
   const colorScheme = useColorScheme() ?? 'light';
   const cardBackground = colorScheme === 'light' ? '#ffffff' : '#0f172a';
   const dividerColor = colorScheme === 'light' ? '#e2e8f0' : '#1f2937';
-  const matchInProgress = matchState.status === 'in-progress';
 
   useEffect(() => {
     if (!matchInProgress) {
       router.replace('/');
     }
   }, [matchInProgress, router]);
-
-  const { teams } = matchState;
-  const orderedTeams = (['sideA', 'sideB'] as TeamId[]).map((id) => teams[id]);
 
   const handleAddPoint = useCallback(
     (teamId: TeamId) => {
@@ -49,7 +55,6 @@ export default function ScoreboardScreen() {
   }
 
   const topBarMatchType = matchState.matchType === 'singles' ? 'Singles' : 'Doubles';
-  const canUndo = matchState.history.length > 0;
 
   return (
     <ThemedView style={styles.container}>

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -16,12 +16,11 @@ import { PlayerNameInput, PrimaryButton } from '#/components/shared';
 import { ThemedText } from '#/components/themed-text';
 import { ThemedView } from '#/components/themed-view';
 import { useColorScheme } from '#/hooks/use-color-scheme';
-import { useMatch } from '#/state/MatchContext';
-import type { MatchType } from '#/types/match';
+import { useAppDispatch } from '#/redux/hooks';
+import { startMatch } from '#/redux/matchSlice';
+import type { MatchType, TeamId } from '#/types/match';
 
-type TeamKey = 'sideA' | 'sideB';
-
-type PlayerNamesState = Record<TeamKey, [string, string]>;
+type PlayerNamesState = Record<TeamId, [string, string]>;
 
 const initialPlayerNames: PlayerNamesState = {
   sideA: ['', ''],
@@ -30,7 +29,7 @@ const initialPlayerNames: PlayerNamesState = {
 
 export default function SetupScreen() {
   const router = useRouter();
-  const { startMatch } = useMatch();
+  const dispatch = useAppDispatch();
   const [matchType, setMatchType] = useState<MatchType>('singles');
   const [playerNames, setPlayerNames] = useState<PlayerNamesState>(initialPlayerNames);
   const [showValidation, setShowValidation] = useState(false);
@@ -75,7 +74,7 @@ export default function SetupScreen() {
     setShowValidation(false);
   }, []);
 
-  const handleNameChange = useCallback((team: TeamKey, index: 0 | 1, value: string) => {
+  const handleNameChange = useCallback((team: TeamId, index: 0 | 1, value: string) => {
     setPlayerNames((current) => {
       const updatedTeam = [...current[team]] as [string, string];
       updatedTeam[index] = value;
@@ -93,9 +92,9 @@ export default function SetupScreen() {
       return;
     }
 
-    startMatch({ matchType, playerNames });
+    dispatch(startMatch({ matchType, playerNames }));
     router.push('/scoreboard');
-  }, [allNamesProvided, matchType, playerNames, router, startMatch]);
+  }, [allNamesProvided, dispatch, matchType, playerNames, router]);
 
   const nameError = showValidation ? 'Please enter a name' : undefined;
 


### PR DESCRIPTION
## Summary
- add a Redux match slice and typed hooks to manage scoring state and history
- wrap the app layout with the Redux provider
- connect the setup and scoreboard screens to the Redux store for starting matches, scoring, and undo actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e25982bb988320b9256ccc022fa753